### PR TITLE
Notebook connection fix

### DIFF
--- a/code-server/notebook-instances/code-server-setup.py
+++ b/code-server/notebook-instances/code-server-setup.py
@@ -280,7 +280,7 @@ c.ServerProxy.servers = {{
 }}
 # Additional settings for Jupyter server
 c.NotebookApp.keep_alive = True
-c.NotebookApp.connection_timeout = 60000  # 60 seconds
+c.NotebookApp.connection_timeout = 1800000  # 30 minutes
 """
             )
     jupyter_lab_version = subprocess.check_output(

--- a/code-server/notebook-instances/code-server-setup.py
+++ b/code-server/notebook-instances/code-server-setup.py
@@ -275,9 +275,12 @@ c.ServerProxy.servers = {{
             'SHELL': '{args.shell_executable}'
         }},
         'absolute_url': False,
-        'timeout': 30
+        'timeout': 60
     }}
 }}
+# Additional settings for Jupyter server
+c.NotebookApp.keep_alive = True
+c.NotebookApp.connection_timeout = 60000  # 60 seconds
 """
             )
     jupyter_lab_version = subprocess.check_output(

--- a/code-server/notebook-instances/code-server-setup.py
+++ b/code-server/notebook-instances/code-server-setup.py
@@ -279,8 +279,9 @@ c.ServerProxy.servers = {{
     }}
 }}
 # Additional settings for Jupyter server
-c.NotebookApp.keep_alive = True
-c.NotebookApp.connection_timeout = 1800000  # 30 minutes
+c.NotebookApp.shutdown_no_activity_timeout = 3600 #60 minutes
+c.MappingKernelManager.cull_idle_timeout = 3600   #60 minutes
+c.MappingKernelManager.cull_interval = 300   #5 minutes
 """
             )
     jupyter_lab_version = subprocess.check_output(
@@ -296,6 +297,7 @@ c.NotebookApp.connection_timeout = 1800000  # 30 minutes
 
     conda_setup_commands = [
         ["pip", "uninstall", "--yes", "nbserverproxy", ";"],
+        ["jupyter", "serverextension", "disable", "nbserverproxy"],
         [
             "pip",
             "install",


### PR DESCRIPTION
c.NotebookApp.keep_alive = True:

This setting ensures that the connection between the client browser and the Jupyter server remains active. When set to True, it prevents the connection from being dropped during periods of inactivity, allowing us to keep working without interruptions.

c.NotebookApp.connection_timeout = 1800000:

This specifies the time (in milliseconds) the server will wait before timing out a connection. In this case, 30 minutes. If there’s no activity during this period, the server may close the connection. 